### PR TITLE
REL: 1.0.2

### DIFF
--- a/adaptoctree/__version.py
+++ b/adaptoctree/__version.py
@@ -1,3 +1,3 @@
 __title__ = 'adaptoctree'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __description__ = 'Linear Adaptive Octrees in Python'

--- a/adaptoctree/test/test_morton.py
+++ b/adaptoctree/test/test_morton.py
@@ -256,7 +256,7 @@ def test_find_parent(key, expected):
     "key, x0, r0, expected",
     [
         (
-            0, np.array([1, 1, 1]), 1, np.array([[0, 0, 0], [2, 2, 2]])
+            0, np.array([1, 1, 1], dtype=np.float64), 1., np.array([[0, 0, 0], [2, 2, 2]])
         )
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(PATH_VERSION, mode='r', encoding='utf-8') as f:
     exec(f.read(), ABOUT)
 
 requirements = [
-    "numba==0.52.0",
+    "numba==0.53.0",
     "pytest==6.2.2"
 ]
 


### PR DESCRIPTION
- Add some missing JITS to coordinate functions
- Update Numba Version, hence new release version. This is required so that cache can be created for weakref objects (i.e. other numba functions) added in 0.53